### PR TITLE
Implement workout persistence

### DIFF
--- a/WorkoutModel/Sources/Workout.swift
+++ b/WorkoutModel/Sources/Workout.swift
@@ -1,18 +1,49 @@
 import Foundation
 
-public struct Workout: Identifiable {
-    public let id = UUID()
+public struct Workout: Identifiable, Codable {
+    public let id: UUID
     public let date: Date
     public let weight: Double
+
+    public init(id: UUID = UUID(), date: Date, weight: Double) {
+        self.id = id
+        self.date = date
+        self.weight = weight
+    }
 }
 
 public final class WorkoutStore {
     public private(set) var workouts: [Workout] = []
+    private let fileURL: URL
 
-    public init() {}
+    public init(fileURL: URL = WorkoutStore.defaultFileURL) {
+        self.fileURL = fileURL
+    }
 
     public func add(weight: Double, date: Date = Date()) {
         let workout = Workout(date: date, weight: weight)
         workouts.append(workout)
+    }
+
+    public func save() throws {
+        let data = try JSONEncoder().encode(workouts)
+        try data.write(to: fileURL, options: .atomic)
+    }
+
+    public func load() throws {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            workouts = []
+            return
+        }
+        let data = try Data(contentsOf: fileURL)
+        workouts = try JSONDecoder().decode([Workout].self, from: data)
+    }
+
+    public static var defaultFileURL: URL {
+        if let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
+            return dir.appendingPathComponent("workouts.json")
+        } else {
+            return URL(fileURLWithPath: FileManager.default.currentDirectoryPath).appendingPathComponent("workouts.json")
+        }
     }
 }

--- a/WorkoutModel/Tests/WorkoutModelTests.swift
+++ b/WorkoutModel/Tests/WorkoutModelTests.swift
@@ -9,10 +9,28 @@ final class WorkoutModelTests: XCTestCase {
         XCTAssertEqual(store.workouts.count, 1)
         XCTAssertEqual(store.workouts.first?.weight, 75)
     }
+
+    func testSaveAndLoad() throws {
+        let tempURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString + ".json")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let store = WorkoutStore(fileURL: tempURL)
+        store.add(weight: 60, date: Date(timeIntervalSince1970: 0))
+        store.add(weight: 70, date: Date(timeIntervalSince1970: 100))
+        try store.save()
+
+        let newStore = WorkoutStore(fileURL: tempURL)
+        try newStore.load()
+
+        XCTAssertEqual(newStore.workouts.count, 2)
+        XCTAssertEqual(newStore.workouts[0].weight, 60)
+        XCTAssertEqual(newStore.workouts[1].weight, 70)
+    }
 }
 
 extension WorkoutModelTests {
     static let allTests = [
-        ("testAddWorkout", testAddWorkout)
+        ("testAddWorkout", testAddWorkout),
+        ("testSaveAndLoad", testSaveAndLoad)
     ]
 }


### PR DESCRIPTION
## Summary
- make `Workout` codable
- add JSON file-based persistence methods in `WorkoutStore`
- test saving and loading workouts

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_684ab26a764c8322b74d957e7ff494d1