### PR TITLE
Add basic ContentView store test

### DIFF
--- a/WorkoutTracker/Sources/ContentView.swift
+++ b/WorkoutTracker/Sources/ContentView.swift
@@ -6,7 +6,14 @@ import Charts
 #if canImport(SwiftUI)
 struct ContentView: View {
     @State private var weight: Double = 50
-    @StateObject private var store = WorkoutStore()
+    @StateObject private var store: WorkoutStore
+
+    /// Exposes the underlying store for unit testing.
+    var storeRef: WorkoutStore { store }
+
+    init(store: WorkoutStore = WorkoutStore()) {
+        _store = StateObject(wrappedValue: store)
+    }
 
     var body: some View {
         NavigationView {
@@ -41,7 +48,13 @@ struct ContentView: View {
 }
 #else
 /// Placeholder to allow building on platforms without SwiftUI.
-struct ContentView {}
+struct ContentView {
+    var store: WorkoutStore
+
+    init(store: WorkoutStore = WorkoutStore()) {
+        self.store = store
+    }
+}
 #endif
 
 #if canImport(SwiftUI)

--- a/WorkoutTracker/Tests/WorkoutTrackerTests/ContentViewStoreTests.swift
+++ b/WorkoutTracker/Tests/WorkoutTrackerTests/ContentViewStoreTests.swift
@@ -1,0 +1,14 @@
+#if !canImport(SwiftUI)
+import XCTest
+@testable import WorkoutTracker
+
+final class ContentViewStoreTests: XCTestCase {
+    func testStoreUpdatesWhenAddingWorkout() {
+        let store = WorkoutStore()
+        var view = ContentView(store: store)
+        XCTAssertEqual(view.store.workouts.count, 0)
+        view.store.add(weight: 80)
+        XCTAssertEqual(view.store.workouts.count, 1)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- expose `WorkoutStore` via init for `ContentView`
- add a Linux-friendly test verifying `ContentView` uses the injected store

## Testing
- `swift test --package-path WorkoutTracker`
- `swift test --package-path WorkoutModel`


------
https://chatgpt.com/codex/tasks/task_e_684ab26cb358832290aebf40804ddaf9